### PR TITLE
Add Stackscript logging - Ant Media

### DIFF
--- a/antmedia/stackscript.sh
+++ b/antmedia/stackscript.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+## Enable logging
+set -o pipefail
+exec > >(tee /dev/ttyS0 /var/log/stackscript.log) 2>&1
+
 ZIP_FILE="https://github.com/ant-media/Ant-Media-Server/releases/download/ams-v2.4.1/ant-media-server-community-2.4.1.zip"
 INSTALL_SCRIPT="https://raw.githubusercontent.com/ant-media/Scripts/master/install_ant-media-server.sh"
 
@@ -11,4 +15,3 @@ else
   logger "There is a problem in installing the ant media server. Please send the log of this console to contact@antmedia.io"
   exit 1
 fi
-   


### PR DESCRIPTION
This PR updates the Ant Media stackscript to add logging to output to the LISH console and to /var/log/stackscript.log to match our other Marketplace apps.