### PR TITLE
Update VictoriaMetrics Single to latest v1.75.0 version

### DIFF
--- a/victoriametrics-single/template.md
+++ b/victoriametrics-single/template.md
@@ -14,7 +14,7 @@ For reading the data and evaluating alerting rules, VictoriaMetrics supports the
 [VictoriaMetrics Single](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html) = Hassle-free monitoring solution. Easily handles 10M+ of active time series on a single instance. Perfect for small and medium environments.
 
 ### Version Number
-1.74.0
+1.75.0
 
 ### Support URL
 * [VictoriaMetrics Twitter](https://twitter.com/MetricsVictoria)

--- a/victoriametrics-single/victoriametrics_stackscript.sh
+++ b/victoriametrics-single/victoriametrics_stackscript.sh
@@ -91,7 +91,7 @@ On the server:
   * The default VictoriaMetrics root is located at /var/lib/victoria-metrics-data
   * VictoriaMetrics is running on ports: 8428, 8089, 4242, 2003 and they are bound to the local interface.
 ********************************************************************************
-  # This image includes version v1.74.0 of VictoriaMetrics. 
+  # This image includes version v1.75.0 of VictoriaMetrics. 
   # See Release notes https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.70.0
 
   # Welcome to VictoriaMetrics droplet!


### PR DESCRIPTION
This PR contains updates to the latest version of VictoriaMetrics - [v1.75.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.75.0)

