### PR TITLE
bump version to the latest v1.82.0

### DIFF
--- a/victoriametrics-single/template.md
+++ b/victoriametrics-single/template.md
@@ -14,7 +14,7 @@ For reading the data and evaluating alerting rules, VictoriaMetrics supports the
 [VictoriaMetrics Single](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html) = Hassle-free monitoring solution. Easily handles 10M+ of active time series on a single instance. Perfect for small and medium environments.
 
 ### Version Number
-[1.77.2](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.77.2)
+[1.80.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.80.0)
 
 ### Support URL
 * [VictoriaMetrics Twitter](https://twitter.com/MetricsVictoria)

--- a/victoriametrics-single/template.md
+++ b/victoriametrics-single/template.md
@@ -14,7 +14,7 @@ For reading the data and evaluating alerting rules, VictoriaMetrics supports the
 [VictoriaMetrics Single](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html) = Hassle-free monitoring solution. Easily handles 10M+ of active time series on a single instance. Perfect for small and medium environments.
 
 ### Version Number
-[1.80.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.80.0)
+[1.80.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.82.0)
 
 ### Support URL
 * [VictoriaMetrics Twitter](https://twitter.com/MetricsVictoria)

--- a/victoriametrics-single/victoriametrics_stackscript.sh
+++ b/victoriametrics-single/victoriametrics_stackscript.sh
@@ -65,7 +65,7 @@ cat <<END >/etc/victoriametrics/single/victoriametrics.conf
 ARGS="-promscrape.config=/etc/victoriametrics/single/scrape.yml -storageDataPath=/var/lib/victoria-metrics-data -retentionPeriod=12 -httpListenAddr=:8428 -graphiteListenAddr=:2003 -opentsdbListenAddr=:4242 -influxListenAddr=:8089 -enableTCP6"
 END
 
-cat <<END /etc/victoriametrics/single/scrape.yml
+cat <<END >/etc/victoriametrics/single/scrape.yml
 # Scrape config example
 #
 scrape_configs:

--- a/victoriametrics-single/victoriametrics_stackscript.sh
+++ b/victoriametrics-single/victoriametrics_stackscript.sh
@@ -21,7 +21,7 @@ chown -R victoriametrics:victoriametrics /var/lib/victoria-metrics-data
 
 # Install VictoriaMetrics Single
 VM_VERSION=`curl -sg "https://api.github.com/repos/VictoriaMetrics/VictoriaMetrics/tags" | jq -r '.[0].name'`
-wget https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/${VM_VERSION}/victoria-metrics-amd64-${VM_VERSION}.tar.gz  -O /tmp/victoria-metrics.tar.gz
+wget https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/${VM_VERSION}/victoria-metrics-linux-amd64-${VM_VERSION}.tar.gz  -O /tmp/victoria-metrics.tar.gz
 tar xvf /tmp/victoria-metrics.tar.gz -C /usr/bin
 chmod +x /usr/bin/victoria-metrics-prod
 chown root:root /usr/bin/victoria-metrics-prod


### PR DESCRIPTION
UPDATE: bumped version of VictoriaMetrics Single node to the latest [v1.82.0](https://docs.victoriametrics.com/CHANGELOG.html#v1820)