### PR TITLE
Update Easypanel

### DIFF
--- a/easypanel/documentation.md
+++ b/easypanel/documentation.md
@@ -44,6 +44,6 @@ After providing all required Linode Options, click on the **Create** button. **Y
 
 ## Getting Started after Deployment
 
-After creating your Linode, you can access Easypanel using the IP address of your server.
+After creating your Linode, you can access Easypanel using the IP address of your server on port 3000.
 
 {{< content "marketplace-update-note">}}

--- a/easypanel/template.md
+++ b/easypanel/template.md
@@ -22,7 +22,7 @@ Easypanel is a modern server control panel which uses Docker under the hood. You
 
 ### Operating System
 
-Ubuntu 20.04 LTS
+Ubuntu 22.04 LTS
 
 ### Documentation
 

--- a/easypanel/template.md
+++ b/easypanel/template.md
@@ -26,7 +26,7 @@ Ubuntu 20.04 LTS
 
 ### Documentation
 
-After creating your Linode, you can access Easypanel using the IP address of your server.
+After creating your Linode, you can access Easypanel using the IP address of your server on port 3000.
 
 ## App Assets
 


### PR DESCRIPTION
- Easypanel can run on Ubuntu 22.04 instead of 20.04
- users can access the panel on `ip:3000` instead of `ip`