### PR TITLE
bump version to the latest v1.87.1 LTS

### DIFF
--- a/victoriametrics-single/template.md
+++ b/victoriametrics-single/template.md
@@ -14,7 +14,7 @@ For reading the data and evaluating alerting rules, VictoriaMetrics supports the
 [VictoriaMetrics Single](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html) = Hassle-free monitoring solution. Easily handles 10M+ of active time series on a single instance. Perfect for small and medium environments.
 
 ### Version Number
-[1.80.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.82.0)
+[1.87.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.87.1)
 
 ### Support URL
 * [VictoriaMetrics Twitter](https://twitter.com/MetricsVictoria)

--- a/victoriametrics-single/victoriametrics_stackscript.sh
+++ b/victoriametrics-single/victoriametrics_stackscript.sh
@@ -91,8 +91,8 @@ On the server:
   * The default VictoriaMetrics root is located at /var/lib/victoria-metrics-data
   * VictoriaMetrics is running on ports: 8428, 8089, 4242, 2003 and they are bound to the local interface.
 ********************************************************************************
-  # This image includes version v1.77.2 of VictoriaMetrics. 
-  # See Release notes https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.77.2
+  # This image includes version v1.87.1 of VictoriaMetrics. 
+  # See Release notes https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.87.1
 
   # Welcome to VictoriaMetrics droplet!
   # Website:       https://victoriametrics.com


### PR DESCRIPTION
bumped version of VictoriaMetrics Single node to the latest [v1.87.1](https://docs.victoriametrics.com/CHANGELOG.html#v1871)